### PR TITLE
allow comments in the colander file (like in the example)

### DIFF
--- a/lib/strainer/runner.rb
+++ b/lib/strainer/runner.rb
@@ -37,7 +37,8 @@ module Strainer
       file = file.gsub('$COOKBOOK', cookbook_name)
       file = file.gsub('$SANDBOX', @sandbox.sandbox_path)
 
-      lines = file.split("\n").reject{|c| c.strip.empty?}.compact
+      # drop empty lines and comments
+      lines = file.split("\n").reject{|c| c.strip.empty? || c.start_with?('#')}.compact
 
       # parse the line and split it into the label and command parts
       #


### PR DESCRIPTION
The example in the README.md has a comment in the Colanderfile... and it makes strain explode. This change allows comments in the Colanderfile.
