### PR TITLE
Support streaming output

### DIFF
--- a/lib/strainer/command.rb
+++ b/lib/strainer/command.rb
@@ -35,12 +35,12 @@ module Strainer
 
       Dir.chdir Strainer.sandbox_path do
         speak command
-        PTY.spawn command do |, w, pid|
+        PTY.spawn command do |r, _, pid|
           begin
             r.sync
             r.each_line { |line| speak line }
           rescue Errno::EIO => e
-            # simply ignoring this
+            $stderr.puts e
           ensure
             ::Process.wait pid
           end


### PR DESCRIPTION
I use vagrant + chef-minitest which takes a long time.  I want to see output in realtime, so I replaced the backticks with a call to PTY.spawn

Use PTY.spawn to stream output of the executed commands
in real time.
