### PR TITLE
Sandbox root folders missing 2 random files!

### DIFF
--- a/lib/strainer/sandbox.rb
+++ b/lib/strainer/sandbox.rb
@@ -231,9 +231,9 @@ module Strainer
       # @return [Array]
       #   the list of root-level directories
       def root_folders
-        @root_folders ||= Dir.glob("#{Dir.pwd}/*", File::FNM_DOTMATCH).tap { |a| a.shift(2) }.collect do |f|
+        @root_folders ||= Dir.glob("#{Dir.pwd}/*", File::FNM_DOTMATCH).collect do |f|
           File.basename(f) if File.directory?(f)
-        end.compact
+        end.reject!{|dir| %w(. ..).include? dir}.compact!
       end
 
       # Determine if the current project is a git repo?


### PR DESCRIPTION
Strainer is failing on my Jenkins box, and on examination the Sandbox doesn't believe my chef repo is a chef repo as it's missing some of the expected directories. They're actually there and it seems the root folders code is throwing away 2 filenames - I suspect this was meant to be '.' and '..' but these aren't always at the front of a glob.

Replace this code with an explicit rejection of '.' and '..' and strainer works again on all boxes.
