### PR TITLE
Fix typo in rake_tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ require 'strainer/rake_task'
 
 Strainer::RakeTask.new(:strainer) do |s|
   s.except = [...]
-  s.strainerfile = 'MyStraienrfile'
+  s.strainerfile = 'MyStrainerfile'
 end
 ```
 

--- a/lib/strainer/rake_task.rb
+++ b/lib/strainer/rake_task.rb
@@ -60,7 +60,7 @@ module Strainer
       end
     end
 
-    Striner::Cli.commands['test'].options.each do |key|
+    Strainer::Cli.commands['test'].options.each do |key|
       name = key.first
 
       define_method(name) do


### PR DESCRIPTION
Fix the reference to the Strainer module in the rake_task
class.
