### PR TITLE
Fix Thor aliases

### DIFF
--- a/lib/strainer/cli.rb
+++ b/lib/strainer/cli.rb
@@ -64,7 +64,7 @@ module Strainer
     class_option :cookbooks_path, :type => :string,  :aliases => '-p',  :desc => 'The path to the cookbook store', :banner => 'PATH'
     class_option :config,         :type => :string,  :aliases => '-c',  :desc => 'The path to the knife.rb/client.rb config'
     class_option :strainer_file,  :type => :string,  :aliases => '-s',  :desc => 'The path to the Strainer file to run against', :banner => 'FILE', :default => Strainer::Strainerfile::DEFAULT_FILENAME
-    class_option :sandbox,        :type => :string,  :aliases => '-s',  :desc => 'The sandbox path (defaults to a temporary directory)', :default => Dir.mktmpdir
+    class_option :sandbox,        :type => :string,  :aliases => '-S',  :desc => 'The sandbox path (defaults to a temporary directory)', :default => Dir.mktmpdir
     class_option :debug,          :type => :boolean, :aliases => '-d',  :desc => 'Show debugging log output', :default => false
     class_option :color,          :type => :boolean, :aliases => '-C',  :desc => 'Enable color in Strainer output', :default => !Buff::Platform.windows?
 


### PR DESCRIPTION
Fix some problems with the Thor aliases, namely:
- There was a conflicting alias.
- Multi-character aliases aren't supported by Thor.

On [multi-character aliases](https://github.com/erikhuda/thor/wiki/Method-Options#default-values):

> Note: Thor follows a convention of one-dash-one-letter options. Thus aliases like "-something" wont be parsed; use either "--something" or "-s" instead.
