### PR TITLE
Loosen the berkshelf version restriction

### DIFF
--- a/strainer.gemspec
+++ b/strainer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'strainer'
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency 'berkshelf',     '~> 2.0'
+  gem.add_runtime_dependency 'berkshelf',     '>= 2.0'
   gem.add_runtime_dependency 'buff-platform', '~> 0.1'
 
   gem.add_development_dependency 'redcarpet'


### PR DESCRIPTION
I don't care where it's `>= 2` or `~> 3.0` or something, but can we move this forward since the berkshelf maintainers are recommending 3.

I need this so I update berkshelf to show the path and still use strainer.

Ref: https://github.com/berkshelf/berkshelf/pull/1011
