### PR TITLE
Copy .rubocop.yml into sandbox

### DIFF
--- a/lib/strainer/sandbox.rb
+++ b/lib/strainer/sandbox.rb
@@ -91,9 +91,9 @@ module Strainer
       # Copy over a whitelist of common files into our sandbox
       def copy_globals
         if chef_repo?
-          files = Dir[*%W(#{@options['strainer_file']} foodcritic .cane .kitchen.yml Berksfile README.md .rspec spec test)]
+          files = Dir[*%W(#{@options['strainer_file']} foodcritic .cane .rubocop.yml .kitchen.yml Berksfile README.md .rspec spec test)]
         elsif cookbook_repo?
-          files = Dir[*%W(#{@options['strainer_file']} foodcritic .cane .kitchen.yml Berksfile README.md .rspec)]
+          files = Dir[*%W(#{@options['strainer_file']} foodcritic .cane .rubocop.yml .kitchen.yml Berksfile README.md .rspec)]
         else
           files = []
         end


### PR DESCRIPTION
Similar to the copying of `.cane` file, this allows customizing the rubocop ruby style checking rules.

At present, the default rubocop rules don't exclude `vendor/bundle` which means when running strainer on my cookbook repo on travis-ci (and presumably other CI's), rubocop is checking all gems installed from the Gemfile. I'll see about proposing changes to rubocops defaults, but aside from that it would be preferable to also copy across any other customizations
